### PR TITLE
Update pom and test support for Bamboo 6.10

### DIFF
--- a/extension.spec.yaml
+++ b/extension.spec.yaml
@@ -3,7 +3,7 @@ products: [insightappsec]
 name: insightappsec_bamboo_plugin
 title: Atlassian Bamboo Plugin
 description: Integrate InsightAppSec application security scans into Atlassian Bamboo build and release pipelines
-version: 0.2.1
+version: 1.0.0
 vendor: rapid7
 status: []
 support: rapid7

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rapid7.ias.bamboo</groupId>
     <artifactId>insightappsec-bamboo-plugin</artifactId>
-    <version>0.2.1</version>
+    <version>1.0.0</version>
     <scm>
         <url>https://github.com/rapid7/insightappsec-bamboo-plugin</url>
         <connection>scm:git:git@github.com:rapid7/insightappsec-bamboo-plugin.git</connection>
@@ -23,8 +23,8 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <bamboo.version>6.9.2</bamboo.version>
-        <bamboo.data.version>6.9.2</bamboo.data.version>
+        <bamboo.version>6.10.4</bamboo.version>
+        <bamboo.data.version>6.10.4</bamboo.data.version>
         <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>

--- a/src/main/resources/atlassian-plugin-marketing.xml
+++ b/src/main/resources/atlassian-plugin-marketing.xml
@@ -1,7 +1,7 @@
 <atlassian-plugin-marketing>
     <!--Describe names and versions of compatible applications -->
     <compatibility>
-        <product name="bamboo" min="6.3" max="6.9.2"/>
+        <product name="bamboo" min="6.3" max="6.10.4"/>
     </compatibility>
     <!-- Describe your add-on logo and banner. The banner is only displayed in the UPM. -->
     <logo image="images/rapid7-icon.png"/>


### PR DESCRIPTION
### Description
- Validate support for Bamboo 6.10
- Set version to 1.0.0

### Motivation and Context
- Customer need for support of latest version of Bamboo

### How Has This Been Tested?
- Locally tested against Bamboo 6.10.4