### PR TITLE
Implement RuntimeDataProvider to pre-fetch API Key for task

### DIFF
--- a/extension.spec.yaml
+++ b/extension.spec.yaml
@@ -3,7 +3,7 @@ products: [insightappsec]
 name: insightappsec_bamboo_plugin
 title: Atlassian Bamboo Plugin
 description: Integrate InsightAppSec application security scans into Atlassian Bamboo build and release pipelines
-version: 1.0.0
+version: 1.1.0
 vendor: rapid7
 status: []
 support: rapid7

--- a/help.md
+++ b/help.md
@@ -73,6 +73,7 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 
 # Version History
 
+* 1.1.0 - Support for Atlassian Bamboo 7.0.X, Implements RuntimeDataProvider to assist with pre-fetch of API Key for tasks run on remote agents
 * 1.0.0 - Initial integration
 
 # Links

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rapid7.ias.bamboo</groupId>
     <artifactId>insightappsec-bamboo-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <scm>
         <url>https://github.com/rapid7/insightappsec-bamboo-plugin</url>
         <connection>scm:git:git@github.com:rapid7/insightappsec-bamboo-plugin.git</connection>
@@ -23,8 +23,8 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <bamboo.version>6.10.4</bamboo.version>
-        <bamboo.data.version>6.10.4</bamboo.data.version>
+        <bamboo.version>7.0.4</bamboo.version>
+        <bamboo.data.version>7.0.4</bamboo.data.version>
         <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
@@ -100,7 +100,7 @@ public class InsightAppSecHelper {
             ResourceScan scan = scansApi.getScan(UUID.fromString(scanId));
 
             status = new HashMap<String,String>() {{
-                put("Status", scan.getStatus().getValue());
+                put("Status", Objects.toString(scan.getStatus().getValue(), "Unknown"));
                 if (scan.getFailureReason() != null) {
                     put("Reason", Objects.toString(scan.getFailureReason().getValue(), ""));
                 } else {

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
@@ -99,19 +99,23 @@ public class InsightAppSecHelper {
         try {
             ResourceScan scan = scansApi.getScan(UUID.fromString(scanId));
 
-            status = new HashMap<String,String>() {{
-                put("Status", Objects.toString(scan.getStatus().getValue(), "Unknown"));
-                if (scan.getFailureReason() != null) {
-                    put("Reason", Objects.toString(scan.getFailureReason().getValue(), ""));
-                } else {
-                    put("Reason", "");
-                }
-            }};
+            // There are times the API returns null for status; be defensive
+            if (scan.getStatus() != null && scan.getStatus().getValue() != null) {
+                status = new HashMap<String, String>() {{
+                    put("Status", scan.getStatus().getValue());
+                    if (scan.getFailureReason() != null) {
+                        put("Reason", Objects.toString(scan.getFailureReason().getValue(), ""));
+                    } else {
+                        put("Reason", "");
+                    }
+                }};
+            }
         } catch (ApiException iase) {
             logger.error("Failed to retrieve scan by ID " + scanId + ": " + iase.getCode());
             handleException(iase);
+        } finally {
+            return status;
         }
-        return status;
     }
 
     public ResourceScanConfig getScanConfiguration(String scanConfigName, UUID appId) throws InsightAppSecException {

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecRuntimeDataProvider.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecRuntimeDataProvider.java
@@ -1,11 +1,16 @@
 package com.rapid7.ias.bamboo.impl;
 
+import com.atlassian.bamboo.ResultKey;
 import com.atlassian.bamboo.credentials.CredentialsAccessor;
 import com.atlassian.bamboo.credentials.CredentialsData;
+import com.atlassian.bamboo.security.SecureToken;
+import com.atlassian.bamboo.security.SecureTokenService;
+import com.atlassian.bamboo.serialization.WhitelistedSerializable;
 import com.atlassian.bamboo.task.RuntimeTaskDataProvider;
 import com.atlassian.bamboo.task.TaskDefinition;
 import com.atlassian.bamboo.task.runtime.RuntimeTaskDefinition;
 import com.atlassian.bamboo.v2.build.CommonContext;
+import com.atlassian.bamboo.v2.build.agent.messages.AuthenticableMessage;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +30,10 @@ public class InsightAppSecRuntimeDataProvider implements RuntimeTaskDataProvider
                                                        @NotNull CommonContext commonContext) {
         final Map<String, String> configuration = taskDefinition.getConfiguration();
         final Map<String, String> result = new HashMap<>();
+
+        // Get Shared Credential for API auth
         propagateSharedCredentialsValues(InsightAppSecScanTaskConfigurator.SELECTED_CREDENTIAL, taskDefinition, configuration, result);
+
         return result;
     }
 

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecRuntimeDataProvider.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecRuntimeDataProvider.java
@@ -1,0 +1,53 @@
+package com.rapid7.ias.bamboo.impl;
+
+import com.atlassian.bamboo.credentials.CredentialsAccessor;
+import com.atlassian.bamboo.credentials.CredentialsData;
+import com.atlassian.bamboo.task.RuntimeTaskDataProvider;
+import com.atlassian.bamboo.task.TaskDefinition;
+import com.atlassian.bamboo.task.runtime.RuntimeTaskDefinition;
+import com.atlassian.bamboo.v2.build.CommonContext;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.atlassian.bamboo.credentials.UsernamePasswordCredentialType.CFG_PASSWORD;
+
+public class InsightAppSecRuntimeDataProvider implements RuntimeTaskDataProvider, IasConstants {
+    @Inject
+    private CredentialsAccessor credentialsAccessor;
+
+    @NotNull
+    @Override
+    public Map<String, String> populateRuntimeTaskData(@NotNull TaskDefinition taskDefinition,
+                                                       @NotNull CommonContext commonContext) {
+        final Map<String, String> configuration = taskDefinition.getConfiguration();
+        final Map<String, String> result = new HashMap<>();
+        propagateSharedCredentialsValues(InsightAppSecScanTaskConfigurator.SELECTED_CREDENTIAL, taskDefinition, configuration, result);
+        return result;
+    }
+
+    private void propagateSharedCredentialsValues(String sharedCredentialsKey, @NotNull TaskDefinition taskDefinition,
+                                                  Map<String, String> configuration, Map<String, String> result) {
+        final String credentialsId = configuration.get(sharedCredentialsKey);
+        if (StringUtils.isNotBlank(credentialsId)) {
+            final CredentialsData credentials = credentialsAccessor.getCredentials(Long.parseLong(credentialsId));
+            if (credentials == null) {
+                throw new IllegalStateException("Can't find API Key as shared credentials with id " + credentialsId
+                        + " for task "
+                        + (StringUtils.isEmpty(taskDefinition.getUserDescription()) ? taskDefinition.getPluginKey() : taskDefinition.getUserDescription()));
+            }
+
+            // We only need password field for api_key; we don't use the name
+            final String password = credentials.getConfiguration().get(CFG_PASSWORD);
+            result.put(CFG_PASSWORD, password);
+        }
+    }
+
+    @Override
+    public void processRuntimeTaskData(@NotNull RuntimeTaskDefinition runtimeTaskDefinition, @NotNull CommonContext commonContext)
+    {
+    }
+}

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
@@ -4,6 +4,7 @@ import com.atlassian.bamboo.configuration.ConfigurationMap;
 import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContext;
 import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContextImpl;
 import com.atlassian.bamboo.plan.artifact.ArtifactPublishingResult;
+import com.atlassian.bamboo.security.SecureToken;
 import com.atlassian.bamboo.task.*;
 import com.atlassian.bamboo.util.Narrow;
 import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
@@ -210,7 +211,7 @@ public class InsightAppSecScanTask implements CommonTaskType, IasConstants {
 
         logger.info("Publishing artifact(s) for scan");
 
-        ArtifactDefinitionContext artifact = new ArtifactDefinitionContextImpl(name, true, null);
+        ArtifactDefinitionContext artifact = new ArtifactDefinitionContextImpl(name, true, SecureToken.create());
         artifact.setCopyPattern("insightappsec-scan-*.json");
 
         ArtifactPublishingResult result = artifactManager.publish(

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
@@ -46,13 +46,14 @@ public class InsightAppSecScanTask implements CommonTaskType, IasConstants {
 
         // Get RuntimeContext for pre-task pull of API Key
         Map<String, String> runtimeContext = taskContext.getRuntimeTaskContext();
+        final String apiKey = runtimeContext.get(CFG_PASSWORD);
 
         ConfigurationMap configMap = taskContext.getConfigurationMap();
         region = configMap.get(SELECTED_REGION);
         appName = configMap.get(APP_NAME);
         scanConfigName = configMap.get(SCAN_CONFIG_NAME);
 
-        if (runtimeContext.get(CFG_PASSWORD) == null) {
+        if (apiKey == null) {
             logger.error("Previously configured credential is no longer defined within Bamboo; please review task and" +
                     " credential configuration");
             Thread.currentThread().interrupt();
@@ -64,7 +65,7 @@ public class InsightAppSecScanTask implements CommonTaskType, IasConstants {
         logger.info("Scan Config: "+ scanConfigName);
 
         // Initialize helper with necessary clients
-        InsightAppSecHelper iasHelper = new InsightAppSecHelper(region, runtimeContext.get(CFG_PASSWORD), logger);
+        InsightAppSecHelper iasHelper = new InsightAppSecHelper(region, apiKey, logger);
 
         try {
             ResourceApp app = iasHelper.getApplication(appName);

--- a/src/main/resources/atlassian-plugin-marketing.xml
+++ b/src/main/resources/atlassian-plugin-marketing.xml
@@ -1,7 +1,7 @@
 <atlassian-plugin-marketing>
     <!--Describe names and versions of compatible applications -->
     <compatibility>
-        <product name="bamboo" min="6.3" max="6.10.4"/>
+        <product name="bamboo" min="6.3" max="7.0.4"/>
     </compatibility>
     <!-- Describe your add-on logo and banner. The banner is only displayed in the UPM. -->
     <logo image="images/rapid7-icon.png"/>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -26,6 +26,7 @@
         <category name="builder"/>
         <category name="deployment"/>
         <configuration class="com.rapid7.ias.bamboo.impl.InsightAppSecScanTaskConfigurator"/>
+        <runtimeTaskDataProvider class="com.rapid7.ias.bamboo.impl.InsightAppSecRuntimeDataProvider"/>
         <resource type="freemarker" name="edit" location="template/InsightAppSecScanTaskTemplate.ftl"/>
         <resource type="download" name="icon" location="images/rapid7-icon.png"/>
         <help link="task.help.link" title="task.help.title" />

--- a/src/test/java/ut/com/rapid7/ias/bamboo/InsightAppSecScanTaskUnitTest.java
+++ b/src/test/java/ut/com/rapid7/ias/bamboo/InsightAppSecScanTaskUnitTest.java
@@ -10,7 +10,7 @@ public class InsightAppSecScanTaskUnitTest
     @Test
     public void testMyName()
     {
-        InsightAppSecScanTask component = new InsightAppSecScanTask(null, null);
+        InsightAppSecScanTask component = new InsightAppSecScanTask(null);
         assertEquals("names do not match!", "Rapid7 InsightAppSec",component.getName());
     }
 }

--- a/src/test/resources/atlassian-plugin.xml
+++ b/src/test/resources/atlassian-plugin.xml
@@ -10,5 +10,4 @@
 
     <!--&lt;!&ndash; from the product container &ndash;&gt;-->
     <!--<component-import key="applicationProperties" interface="com.atlassian.sal.api.ApplicationProperties" />-->
-    
 </atlassian-plugin>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
- Support for Bamboo 7.0.X
- Implemented RuntimeDataProvider to allow pre-fetching of API key for remote agent tasks


### Motivation and Context
- Remote agents were not able to run scan task due to CredentialsManager not being implemented/shared


### How Has This Been Tested?
- Locally with local agent
- Locally with remote agent


### Types of changes
<!--- What types of changes does your code introduce? Remove any that do not apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


### Checklist:
<!--- After submitting the PR, check all of the boxes that apply. -->
<!--- You may remove any that do not apply or add additional checks as reminders. -->
- [ ] I have updated the documentation accordingly (if changes are required).
- [ ] I have tested the changes locally.


### Miscellaneous Details:
<!--- Provide any additional details you feel are relevant. -->