### PR TITLE
New regions, user agent, scan-config changes

### DIFF
--- a/extension.spec.yaml
+++ b/extension.spec.yaml
@@ -3,7 +3,7 @@ products: [insightappsec]
 name: insightappsec_bamboo_plugin
 title: Atlassian Bamboo Plugin
 description: Integrate InsightAppSec application security scans into Atlassian Bamboo build and release pipelines
-version: 1.1.0
+version: 1.1.1
 vendor: rapid7
 status: []
 support: rapid7

--- a/help.md
+++ b/help.md
@@ -73,6 +73,7 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 
 # Version History
 
+* 1.1.1 - Add new regions to InsightAppSec Region dropdown. Use search endpoint to retrieve scan-configs.
 * 1.1.0 - Support for Atlassian Bamboo 7.0.X, Implements RuntimeDataProvider to assist with pre-fetch of API Key for tasks run on remote agents
 * 1.0.0 - Initial integration
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rapid7.ias.bamboo</groupId>
     <artifactId>insightappsec-bamboo-plugin</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <scm>
         <url>https://github.com/rapid7/insightappsec-bamboo-plugin</url>
         <connection>scm:git:git@github.com:rapid7/insightappsec-bamboo-plugin.git</connection>
@@ -23,8 +23,8 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
-        <bamboo.version>7.0.4</bamboo.version>
-        <bamboo.data.version>7.0.4</bamboo.data.version>
+        <bamboo.version>7.1.1</bamboo.version>
+        <bamboo.data.version>7.1.1</bamboo.data.version>
         <amps.version>6.3.21</amps.version>
         <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
@@ -38,6 +38,7 @@
         <okhttp-version>2.7.5</okhttp-version>
         <gson-version>2.8.1</gson-version>
         <gson-fire-version>1.8.0</gson-fire-version>
+        <mockito-core.version>2.8.9</mockito-core.version>
     </properties>
 
     <dependencies>
@@ -73,6 +74,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/rapid7/ias/bamboo/impl/IasConstants.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/IasConstants.java
@@ -22,7 +22,7 @@ public interface IasConstants {
     String VULN_QUERY_ENFORCEMENT     = "vulnQueryEnforcement";
     String VULN_QUERY                 = "vulnQuery";
 
-    List<String> REGION_OPTIONS_LIST = Arrays.asList("US","EU","AU","CA","AP","OTHER");
+    List<String> REGION_OPTIONS_LIST = Arrays.asList("US","US2","US3","EU","AU","CA","AP","OTHER");
 
     List<String> ADVANCE_ON_OPTIONS_LIST = Arrays.asList(
             "SUBMITTED",

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
@@ -136,9 +136,8 @@ public class InsightAppSecHelper {
             PageScanConfig resultsPage = response.getData();
             List<ResourceScanConfig> results = resultsPage.getData();
 
-            if(results.size() != 1) {
-                logger.error("Number of app's scan configs with name " + scanConfigName + " is " + results.size()
-                                     + ". This should be exactly 1.");
+            if(results == null || results.size() != 1) {
+                logger.error("Number of application's scan configs with name " + scanConfigName + " should be 1.");
                 return null;
             }
 
@@ -147,6 +146,9 @@ public class InsightAppSecHelper {
         catch (ApiException iase) {
             logger.error("InsightAppSec Scan Config Exception: " + iase.getResponseBody() + " (" + iase.getCode() + ")");
             handleException(iase);
+        }
+        catch (Exception e) {
+            logger.error("Exception when calling ScanConfigsApi#getScanConfigs: " + e.toString());
         }
 
         return null;

--- a/src/main/resources/atlassian-plugin-marketing.xml
+++ b/src/main/resources/atlassian-plugin-marketing.xml
@@ -1,7 +1,7 @@
 <atlassian-plugin-marketing>
     <!--Describe names and versions of compatible applications -->
     <compatibility>
-        <product name="bamboo" min="6.3" max="7.0.4"/>
+        <product name="bamboo" min="6.3" max="7.1.1"/>
     </compatibility>
     <!-- Describe your add-on logo and banner. The banner is only displayed in the UPM. -->
     <logo image="images/rapid7-icon.png"/>

--- a/src/test/java/ut/com/rapid7/ias/bamboo/InsightAppSecHelperUnitTest.java
+++ b/src/test/java/ut/com/rapid7/ias/bamboo/InsightAppSecHelperUnitTest.java
@@ -1,0 +1,104 @@
+package ut.com.rapid7.ias.bamboo;
+
+import com.rapid7.ias.bamboo.impl.InsightAppSecHelper;
+import com.rapid7.ias.bamboo.util.UtilityLogger;
+import com.rapid7.ias.client.ApiClient;
+import com.rapid7.ias.client.ApiResponse;
+import com.rapid7.ias.client.api.SearchApi;
+import com.rapid7.ias.client.model.PageScanConfig;
+import com.rapid7.ias.client.model.RequiredIdResource;
+import com.rapid7.ias.client.model.ResourceScanConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InsightAppSecHelperUnitTest {
+
+    @Mock
+    UtilityLogger logger;
+
+    @InjectMocks
+    private InsightAppSecHelper insightAppSecHelper;
+
+    @Test
+    public void testGetScanConfiguration() throws Exception {
+        //Call mockCall = mock(Call.class);
+        ApiClient apiClient = mock(ApiClient.class);
+        ApiResponse response = mock(ApiResponse.class);
+        SearchApi searchApi = mock(SearchApi.class);
+
+        insightAppSecHelper.searchApi = searchApi;
+
+        //when(searchApi.performSearchCall(any(SearchRequest.class), anyInt(), anyInt(), any(), any(), any())).thenReturn(mockCall);
+        when(searchApi.getApiClient()).thenReturn(apiClient);
+        when(apiClient.execute(any(), any())).thenReturn(response);
+        when(response.getData()).thenReturn(getPageScanConfig(1));
+
+        ResourceScanConfig result = insightAppSecHelper.getScanConfiguration("my-scan-config", UUID.randomUUID());
+
+        assertNotNull(result);
+        assertNotNull(result.getApp());
+    }
+
+    @Test
+    public void testGetScanConfigurationError() throws Exception {
+        //Call mockCall = mock(Call.class);
+        ApiClient apiClient = mock(ApiClient.class);
+        ApiResponse response = mock(ApiResponse.class);
+        SearchApi searchApi = mock(SearchApi.class);
+
+        insightAppSecHelper.searchApi = searchApi;
+
+        //when(searchApi.performSearchCall(any(SearchRequest.class), anyInt(), anyInt(), any(), any(), any())).thenReturn(mockCall);
+        when(searchApi.getApiClient()).thenReturn(apiClient);
+        when(apiClient.execute(any(), any())).thenReturn(response);
+        when(response.getData()).thenReturn(getPageScanConfig(0));
+
+        ResourceScanConfig result = insightAppSecHelper.getScanConfiguration("my-scan-config", UUID.randomUUID());
+        assertNull(result);
+
+        when(response.getData()).thenReturn(getPageScanConfig(5));
+
+        result = insightAppSecHelper.getScanConfiguration("my-scan-config", UUID.randomUUID());
+        assertNull(result);
+    }
+
+    // TEST HELPERS
+
+    public PageScanConfig getPageScanConfig(int size) {
+        List<ResourceScanConfig> data = new ArrayList<>(size);
+
+        for(int i = 0; i < size; i++) {
+            data.add(getResourceScanConfig());
+        }
+
+        PageScanConfig pageScanConfig = new PageScanConfig();
+        pageScanConfig.setData(data);
+
+        return pageScanConfig;
+    }
+
+    public ResourceScanConfig getResourceScanConfig(){
+        UUID id = UUID.randomUUID();
+        RequiredIdResource app = new RequiredIdResource();
+        app.id(id);
+
+        ResourceScanConfig resourceScanConfig = new ResourceScanConfig();
+        resourceScanConfig.setApp(app);
+
+        return resourceScanConfig;
+    }
+}


### PR DESCRIPTION
This PR has the following changes:
- Adds US2 and US3 regions to dropdown.
- Adds r7 user agent header to requests.
- Uses search endpoint to retrieve scan-configs instead of scan-configs endpoint. IAS-7110 may cause the plugin validation to fail, this change works around this issue in most cases.
- Some unit tests.


### Motivation and Context
https://issues.corp.rapid7.com/browse/DF-4078
https://issues.corp.rapid7.com/browse/DF-4079


### How Has This Been Tested?
Test plan: https://wiki.corp.rapid7.com/display/EXT/Bamboo+v1.1.1+Test+Plan


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] I have tested the changes locally.