### PR TITLE
IAS-11301 Remediating critical snyk vuln on log4j version

### DIFF
--- a/help.md
+++ b/help.md
@@ -74,7 +74,7 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 # Version History
 
 * 1.2.2 - Update dependencies
-* 1.2.1 - Excusing unnecessary dependencies
+* 1.2.1 - Excluding unnecessary dependencies
 * 1.2.0 - Add proxy connection. Add server logs debugging.
 * 1.1.2 - Update dependencies
 * 1.1.1 - Add new regions to InsightAppSec Region dropdown. Use search endpoint to retrieve scan-configs.

--- a/help.md
+++ b/help.md
@@ -73,7 +73,8 @@ If the scan gating doesn't appear to occur as expected, confirm that the vulnera
 
 # Version History
 
-* 1.2.1 - Update dependencies
+* 1.2.2 - Update dependencies
+* 1.2.1 - Excusing unnecessary dependencies
 * 1.2.0 - Add proxy connection. Add server logs debugging.
 * 1.1.2 - Update dependencies
 * 1.1.1 - Add new regions to InsightAppSec Region dropdown. Use search endpoint to retrieve scan-configs.

--- a/manifest.json
+++ b/manifest.json
@@ -21,12 +21,17 @@
         "sourceUrl": "https://github.com/rapid7/insightappsec-bamboo-plugin",
         "licenseUrl": "https://github.com/rapid7/insightappsec-bamboo-plugin/blob/master/LICENSE"
     },
-    "version": "1.2.1",
+    "version": "1.2.2",
     "versionHistory": [
+        {
+            "version": "1.2.2",
+            "date": "",
+            "changes": "Update dependencies."
+        },
         {
             "version": "1.2.1",
             "date": "",
-            "changes": "Update dependencies."
+            "changes": "Excluding unnecessary dependencies."
         },
         {
             "version": "1.2.0",

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rapid7.ias.bamboo</groupId>
     <artifactId>insightappsec-bamboo-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
 
     <scm>
         <url>https://github.com/rapid7/insightappsec-bamboo-plugin</url>
@@ -41,6 +41,8 @@
         <gson-fire-version>1.8.0</gson-fire-version>
         <mockito-core.version>2.8.9</mockito-core.version>
         <log4j.version>1.2.17-atlassian-18</log4j.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
+        <apache-logging.version>2.21.1</apache-logging.version>
     </properties>
 
     <dependencies>
@@ -94,13 +96,17 @@
                     <groupId>org.apache.activemq</groupId>
                     <artifactId>activemq-openwire-legacy</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>${commons-lang3.version}</version>
         </dependency>
 
         <dependency>
@@ -132,9 +138,9 @@
         </dependency>
 
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${apache-logging.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecHelper.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class InsightAppSecHelper {
 
-    private String USER_AGENT = "r7:insightappsec-bamboo/1.2.1";
+    private String USER_AGENT = "r7:insightappsec-bamboo/1.2.2";
     private String SCAN_CONFIG_QUERY = "scanconfig.app.id='%1$s' && scanconfig.name='%2$s'";
 
     private UtilityLogger logger;

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTask.java
@@ -5,7 +5,12 @@ import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContext;
 import com.atlassian.bamboo.plan.artifact.ArtifactDefinitionContextImpl;
 import com.atlassian.bamboo.plan.artifact.ArtifactPublishingResult;
 import com.atlassian.bamboo.security.SecureToken;
-import com.atlassian.bamboo.task.*;
+import com.atlassian.bamboo.task.CommonTaskContext;
+import com.atlassian.bamboo.task.CommonTaskType;
+import com.atlassian.bamboo.task.TaskContext;
+import com.atlassian.bamboo.task.TaskException;
+import com.atlassian.bamboo.task.TaskResult;
+import com.atlassian.bamboo.task.TaskResultBuilder;
 import com.atlassian.bamboo.util.Narrow;
 import com.atlassian.plugin.spring.scanner.annotation.component.Scanned;
 import com.atlassian.plugin.spring.scanner.annotation.imports.ComponentImport;
@@ -16,9 +21,10 @@ import com.rapid7.ias.bamboo.util.UtilityLogger;
 import com.rapid7.ias.client.model.ResourceApp;
 import com.rapid7.ias.client.model.ResourceScanConfig;
 import com.rapid7.ias.client.model.ResourceVulnerability;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.util.*;
@@ -27,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Scanned
 public class InsightAppSecScanTask implements CommonTaskType, IasConstants {
     private UtilityLogger logger;
-    private static final Logger log = Logger.getLogger(InsightAppSecScanTask.class);
+    private static final Logger log = LogManager.getLogger(InsightAppSecScanTask.class);
 
     private String region;
     private String appName;

--- a/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTaskConfigurator.java
+++ b/src/main/java/com/rapid7/ias/bamboo/impl/InsightAppSecScanTaskConfigurator.java
@@ -13,6 +13,7 @@ import com.atlassian.bamboo.utils.i18n.I18nBeanFactory;
 import static com.atlassian.bamboo.credentials.UsernamePasswordCredentialType.CFG_PASSWORD;
 
 import com.rapid7.ias.client.ApiClient;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,7 +22,7 @@ import com.rapid7.ias.client.model.ResourceApp;
 import com.rapid7.ias.client.model.ResourceScanConfig;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Hashtable;
 import java.util.Map;
@@ -98,7 +99,7 @@ public class InsightAppSecScanTaskConfigurator extends AbstractTaskConfigurator 
     @Override
     public void validate(@NotNull ActionParametersMap params,
                          @NotNull ErrorCollection errorCollection) {
-        Logger log = Logger.getLogger(InsightAppSecScanTaskConfigurator.class);
+        Logger log = LogManager.getLogger(InsightAppSecScanTaskConfigurator.class);
         UtilityLogger logger = new UtilityLogger(log);
 
         super.validate(params, errorCollection);

--- a/src/main/java/com/rapid7/ias/bamboo/util/UtilityLogger.java
+++ b/src/main/java/com/rapid7/ias/bamboo/util/UtilityLogger.java
@@ -1,7 +1,7 @@
 package com.rapid7.ias.bamboo.util;
 
 import com.atlassian.bamboo.build.logger.BuildLogger;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 public class UtilityLogger {
 


### PR DESCRIPTION
### Description
Bumping log4j to an updated version imported via apache.logging rather than log4j.log4j 

### Motivation and Context
log4j.log4j package via the artifactory is outdated and contained snyk vulnerabilities. apache.logging.log4j contains a much more recent version


### How Has This Been Tested?
Run locally

### Types of changes
- Updating logging
- pom bumps
- doc bumps